### PR TITLE
remove xtrace

### DIFF
--- a/git-cache
+++ b/git-cache
@@ -5,7 +5,7 @@ git_cache() {
 }
 
 init() {
-    set -ex
+    set -e
     local _git_dir="$(git_cache rev-parse --git-dir 2>/dev/null)"
     test "$_git_dir" == "." -o "$_git_dir" == ".git" || {
         mkdir -p "${GIT_CACHE_DIR}"
@@ -13,11 +13,11 @@ init() {
         git_cache init --bare
         git_cache config core.compression 1
     }
-    set +ex
+    set +e
 }
 
 add() {
-    set -ex
+    set -e
     if [ $# -eq 1 ]; then
         local repo="$1"
         local name="$(_remote_name $repo)"
@@ -31,24 +31,24 @@ add() {
     else
         echo "git-cache: $url already in cache"
     fi
-    set +ex
+    set +e
 }
 
 update() {
-    set -ex
+    set -e
     local REMOTE=${1:---all}
     git_cache fetch $REMOTE
-    set +ex
+    set +e
 }
 
 is_cached() {
-    set +ex
+    set +e
     local url="$1"
     local REMOTES="$(git_cache remote show)"
     for remote in $REMOTES; do
         test "$(git_cache remote get-url $remote)" == "$url" && return 0
     done
-    set -ex
+    set -e
     return 1
 }
 
@@ -60,14 +60,14 @@ list() {
 }
 
 drop() {
-    set -ex
+    set -e
     local REMOTE=${1}
     [ -z "$REMOTE" ] && {
         echo "usage: git cache drop <name>"
         exit 1
     }
     git_cache remote remove $REMOTE
-    set +ex
+    set +e
 }
 
 _check_commit() {
@@ -79,7 +79,7 @@ _remote_name() {
 }
 
 clone() {
-    set -ex
+    set -e
     local REMOTE="${1}"
     local SHA1="${2}"
     local REMOTE_NAME="$(_remote_name $REMOTE)"
@@ -101,7 +101,7 @@ clone() {
         git clone "${REMOTE}" "${TARGET_PATH}"
         git -C "${TARGET_PATH}" checkout $SHA1
     fi
-    set +ex
+    set +e
 }
 
 usage() {


### PR DESCRIPTION
This commit removes the xtrace option as I find it quite annoying and it is not possible to disable it. If it is needed on-demand, then the option can be set outside shell script.